### PR TITLE
Add 1Password CLI to build

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -22,6 +22,19 @@ dnf5 install -y dosfstools exfatprogs
 # Install ShellCheck for shell script linting during development and CI
 dnf5 install -y ShellCheck
 
+# Install 1Password CLI tool
+rpm --import https://downloads.1password.com/linux/keys/1password.asc
+cat > /etc/yum.repos.d/1password.repo << 'EOF'
+[1password]
+name=1Password Stable Channel
+baseurl=https://downloads.1password.com/linux/rpm/stable/$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://downloads.1password.com/linux/keys/1password.asc
+EOF
+dnf5 install -y 1password-cli
+
 # Use a COPR Example:
 #
 # dnf5 -y copr enable ublue-os/staging


### PR DESCRIPTION
Adds 1Password CLI installation to the build process.

**Changes:**
- Imports 1Password GPG key
- Adds 1Password stable channel repo
- Installs `1password-cli` package via dnf5

**Implementation notes:**
- Uses heredoc for clean repo file creation
- Follows existing package installation patterns
- No sudo usage (running as root in container build)