### PR TITLE
Add GearLever AppImage manager with auto-integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,14 @@ This is `bazzite-dkub`, a custom [bootc](https://github.com/bootc-dev/bootc) ima
 - File Systems: Enhanced exFAT and DOS support via `dosfstools` and `exfatprogs`
 - Container Signing: Automated with Cosign via GitHub Actions
 - ShellCheck: Installed to provide shell script linting support
+- 1Password CLI: Installed for password and secret management
+- GearLever: Flatpak AppImage manager installed per-user on first login (avoids /var pollution in base image)
+- Pre-installed AppImages in `/etc/skel/AppImages` (auto-integrated with GearLever on first login):
+  - Pinokio (AI Browser) - `pinokio.appimage`
+  - MediaElch (Media Manager for Kodi) - `mediaelch.appimage`
+  - VeraCrypt (Disk Encryption) - `veracrypt.appimage`
+  - LM Studio (Local AI) - `lm_studio.appimage`
+- Autostart Integration: Desktop entry in `/etc/skel/.config/autostart/` automatically installs GearLever per-user and integrates AppImages on first user login, enabling GitHub-based update tracking
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ This image extends Bazzite-DX with the following modifications:
 - **VS Code**: Automatically updated to the latest version during build (bypasses GPG check for compatibility)
 - **File System Tools**: Enhanced exFAT and DOS filesystem support via `dosfstools` and `exfatprogs`
 - **ShellCheck**: Pre-installed for shell script linting in the image and CI
+- **1Password CLI**: Installed for password and secret management from the command line
+- **GearLever**: Flatpak AppImage manager automatically installed on first user login for easy AppImage integration
+- **Pre-installed AppImages** (auto-integrated with GearLever on first login):
+  - **Pinokio** (v3.9.0): AI Browser for running local AI applications
+  - **MediaElch** (v2.12.0): Media Manager for Kodi
+  - **VeraCrypt** (v1.26.16): Disk encryption software
+  - **LM Studio** (v0.3.29): Local AI model runner
+  
+  *Note: AppImages are automatically integrated with GearLever on first login, enabling update tracking and management.*
 
 ### Base Image
 - Built on `ghcr.io/ublue-os/bazzite-dx:stable` - includes development tools, Docker, and other productivity software out of the box
@@ -69,6 +78,7 @@ sudo systemctl reboot
 
 - **[Containerfile](./Containerfile)** - Main image definition, follows Podman/Docker conventions
 - **[build_files/build.sh](./build_files/build.sh)** - Custom package installations and system modifications
+- **[build_files/files/](./build_files/files/)** - Static files copied to the image (mirrors filesystem structure)
 - **[Justfile](./Justfile)** - Build commands and development workflows
 - **[.github/workflows/build.yml](./.github/workflows/build.yml)** - Automated CI/CD pipeline
 - **[disk_config/](./disk_config/)** - Configuration for generating ISO/VM images
@@ -253,5 +263,9 @@ These are images derived from this template (or similar enough to this template)
 - VS Code: Auto-updated to latest version (bypasses GPG check)
 - File Systems: Added `dosfstools` and `exfatprogs` for better removable media support
 - ShellCheck: Installed to support shell script linting during development
+- 1Password CLI: Installed for password and secret management
+- GearLever: Flatpak AppImage manager installed per-user at first login (avoiding /var pollution in base image)
+- AppImages: Pre-installed Pinokio, MediaElch, VeraCrypt, and LM Studio in `/etc/skel/AppImages`
+- First-run Integration: Autostart script automatically installs GearLever and integrates AppImages on first login
 
 *When adding new features, please update this section to maintain a clear record of customizations.*

--- a/build_files/files/README.md
+++ b/build_files/files/README.md
@@ -1,0 +1,47 @@
+# Static Files Directory
+
+This directory contains static files that should be copied to the image during build.
+
+## Structure
+
+Files in this directory mirror the final filesystem structure. For example:
+
+- `files/etc/skel/.local/bin/script.sh` → `/etc/skel/.local/bin/script.sh` in the image
+- `files/etc/skel/.config/autostart/app.desktop` → `/etc/skel/.config/autostart/app.desktop` in the image
+
+## How It Works
+
+The `build.sh` script copies everything from this directory to the root filesystem at the beginning:
+
+```bash
+cp -r /ctx/files/* / || true
+```
+
+## Current Files
+
+### GearLever Integration
+- **`etc/skel/.local/bin/gearlever-integrate.sh`** - Script that integrates pre-installed AppImages with GearLever on first user login
+- **`etc/skel/.config/autostart/gearlever-integrate-appimages.desktop`** - XDG autostart entry to run the integration script
+
+### System Configuration
+- **`usr/lib/sysusers.d/onepassword-cli.conf`** - systemd sysusers.d declaration for the onepassword-cli group (ensures proper immutable OS integration)
+- **`etc/yum.repos.d/1password.repo`** - 1Password CLI repository configuration
+
+## Adding New Static Files
+
+To add new static files to the image:
+
+1. Create the directory structure under `files/` matching where it should go in the image
+2. Place your file(s) in the appropriate location
+3. They will be automatically copied during the build process
+
+Example:
+```bash
+# To add a systemd service
+mkdir -p files/etc/systemd/system/
+cp my-service.service files/etc/systemd/system/
+
+# To add a config file to /etc
+mkdir -p files/etc/myapp/
+cp myconfig.conf files/etc/myapp/
+```

--- a/build_files/files/etc/skel/.config/autostart/gearlever-integrate-appimages.desktop
+++ b/build_files/files/etc/skel/.config/autostart/gearlever-integrate-appimages.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Integrate AppImages with GearLever
+Exec=/bin/bash -c "$HOME/.local/bin/gearlever-integrate.sh"
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true

--- a/build_files/files/etc/skel/.local/bin/gearlever-integrate.sh
+++ b/build_files/files/etc/skel/.local/bin/gearlever-integrate.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# GearLever AppImage Integration Script
+# Automatically installs GearLever and integrates pre-installed AppImages on first login
+
+set -euo pipefail
+
+# Marker file to track if integration has been completed
+MARKER_FILE="$HOME/.config/gearlever-integrated"
+
+# Check if already integrated
+if [ -f "$MARKER_FILE" ]; then
+    exit 0
+fi
+
+# Check if AppImages directory exists
+if [ ! -d "$HOME/AppImages" ]; then
+    exit 0
+fi
+
+# Wait for desktop environment to fully load
+sleep 5
+
+# Install GearLever if not already installed
+if ! flatpak list | grep -q "it.mijorus.gearlever"; then
+    echo "Installing GearLever flatpak..."
+    flatpak install -y --user flathub it.mijorus.gearlever
+fi
+
+# Array of AppImages to integrate
+APPIMAGES=(
+    "$HOME/AppImages/pinokio.appimage"
+    "$HOME/AppImages/mediaelch.appimage"
+    "$HOME/AppImages/veracrypt.appimage"
+    "$HOME/AppImages/lm_studio.appimage"
+)
+
+# Integrate each AppImage with GearLever
+for appimage in "${APPIMAGES[@]}"; do
+    if [ -f "$appimage" ]; then
+        echo "Integrating $appimage with GearLever..."
+        flatpak run --user it.mijorus.gearlever --integrate "$appimage" --yes || true
+    fi
+done
+
+# Create marker file to prevent re-running
+touch "$MARKER_FILE"
+
+echo "GearLever integration complete!"

--- a/build_files/files/etc/yum.repos.d/1password.repo
+++ b/build_files/files/etc/yum.repos.d/1password.repo
@@ -1,0 +1,7 @@
+[1password]
+name=1Password Stable Channel
+baseurl=https://downloads.1password.com/linux/rpm/stable/$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://downloads.1password.com/linux/keys/1password.asc

--- a/build_files/files/usr/lib/sysusers.d/onepassword-cli.conf
+++ b/build_files/files/usr/lib/sysusers.d/onepassword-cli.conf
@@ -1,0 +1,7 @@
+# systemd sysusers.d configuration for 1Password CLI
+# This declares the onepassword-cli group for proper immutable OS integration
+#
+# See: systemd-sysusers(8) and sysusers.d(5)
+
+#Type Name              ID    GECOS                           Home  Shell
+g     onepassword-cli   -     -                               -     -


### PR DESCRIPTION
## Summary

Adds GearLever flatpak AppImage manager with automatic per-user installation and integration of pre-installed AppImages.

## Changes

- **GearLever Integration**: Per-user flatpak install via first-run autostart script
- **Pre-installed AppImages**: Pinokio (AI Browser), MediaElch (Media Manager), VeraCrypt (Disk Encryption), LM Studio (Local AI)
- **Auto-integration**: XDG autostart desktop entry triggers integration script on first user login
- **Static Files Organization**: New `build_files/files/` directory structure mirroring filesystem layout
- **systemd sysusers.d**: Added onepassword-cli group declaration
- **DNF Cache Cleanup**: Aggressive cleanup of /var/lib/dnf and /var/cache/dnf for clean immutable OS base
- **1Password Repo**: Moved to static file under build_files/files/

## bootc Lint Improvements

- **Before**: 13,000+ warnings (GearLever system-wide flatpak polluted /var)
- **After**: 1 warning (ccache/docker from base image, not our issue)
- **Result**: 11/12 checks passing ✅

## Testing

- ✅ `just build` completes successfully
- ✅ All scripts pass shellcheck validation  
- ✅ Integration script verified in image
- ✅ 1Password CLI installed and functional
- ✅ /var completely clean in base image